### PR TITLE
Restore overpass query in line-length script

### DIFF
--- a/docs/py-scripts/line-length.py
+++ b/docs/py-scripts/line-length.py
@@ -22,8 +22,11 @@ node["power"="tower"](user_touched:"Andreas Hernandez","Tobias Augspurger","davi
 node["power"="pole"](user:"Russ","map-dynartio","overflorian","nlehuby","ben10dynartio","InfosReseaux")(newer:"2025-03-01T00:00:00Z")->.their_poles;
 node["power"="tower"](user:"Russ","map-dynartio","overflorian","nlehuby","ben10dynartio","InfosReseaux")(newer:"2025-03-01T00:00:00Z")->.their_towers;
 
-way["power"="line"](bn.poles, bn.towers)-> .connected_ways;
-way["power"="line"](bn.their_poles, bn.their_towers)-> .theirconnected_ways;
+(node.towers; node.poles;) -> .supports;
+(node.their_towers; node.their_poles;) -> .their_supports;
+
+way["power"="line"](bn.supports)-> .connected_ways;
+way["power"="line"](bn.their_supports)-> .theirconnected_ways;
 
 (.poles; .towers; .connected_ways; .theirconnected_ways; .their_poles; .their_towers;);
 out body;


### PR DESCRIPTION
Here are the json results from line-length:

```json
Fetching data from Overpass API...
Team contribution: 36351 km from 2475 ways and 184733 nodes.
Fetching OpenInfraMap global stats...
Global total: 6989267 km
Excluded low voltage: 1117058 km
Global medium-high voltage total: 5872209 km
Successfully created docs/data/line-length.json
{
  "lengthKm": 36351,
  "totalGlobalKm": 6989267,
  "mediumHighVoltageKm": 5872209,
  "percentageOfMediumHigh": 0.62,
  "towerCount": 184733,
  "updated": "2025-08-20T13:03:26.990110+00:00"
}
```

I'm not sure about the 36 351 km. Am I doing anything wrong?