### PR TITLE
add tukrey and wikidat option to overpass

### DIFF
--- a/docs/map-it.md
+++ b/docs/map-it.md
@@ -708,7 +708,13 @@ async function handleAreaClick(iso, level, layer) {
     }
     else {
        let tpl = await fetchQuery(currentMode, level);
-       tpl = tpl.replace(/\$\{iso\}/g, iso);
+       const wikidata = layer.feature.properties.wikidata;
+       const areaFilter = iso
+          ? `["ISO3166-2"="${iso}"]`
+          : `["wikidata"="${wikidata}"]`;
+       tpl = tpl
+          .replace(/\$\{iso\}/g, iso ?? 'NOMATCH')
+          .replace(/\$\{wikidata\}/g, layer.feature.properties.wikidata ?? 'NOMATCH');
        sendToJosm(tpl, name); 
     }
   } catch (err) {


### PR DESCRIPTION
Added wikidata id to turkey in geojson. changed mapit to also take wikidata qid, also changed the overpass in the other repo
<img width="2528" height="1585" alt="image" src="https://github.com/user-attachments/assets/8604e0fe-98b8-478f-870e-8b116c65d83e" />

Both none wikidata and wikidata regions still work