### PR TITLE
remove grey space on sides of tiles

### DIFF
--- a/docs/map-it.md
+++ b/docs/map-it.md
@@ -311,7 +311,7 @@ function hideLabel() { hoverLabel.style.display = 'none'; }
 const map = L.map("map", {
   minZoom:              3,
   maxZoom:              18,
-  maxBounds:            [[-80, -230], [85, 195]],
+  maxBounds:            [[-80, -220], [85, 190]],
   maxBoundsViscosity:   1.0,
   worldCopyJump:        false,
   zoomControl: false // this disables the zoom buttons on the left side
@@ -321,7 +321,7 @@ const map = L.map("map", {
 L.tileLayer("https://server.arcgisonline.com/ArcGIS/rest/services/World_Shaded_Relief/MapServer/tile/{z}/{y}/{x}", {
   attribution: "Tiles &copy; <a href='https://www.esri.com' target='_blank'>Esri</a>, USGS, NOAA | © <a href='https://www.openstreetmap.org/copyright' target='_blank'>OpenStreetMap</a> contributors",
   maxZoom: 19,
-  noWrap:  true // noWrap: true stops the tile layer from repeating tiles outside [-180, 180].
+  noWrap:  false, // noWrap: true stops the tile layer from repeating tiles outside [-180, 180].
 }).addTo(map);
 
 // Zoom buttons top right

--- a/docs/stylesheets/mapit.css
+++ b/docs/stylesheets/mapit.css
@@ -86,7 +86,7 @@ body:has(#mapit-root) .md-content__inner > h1 {
   position: absolute;
   inset: 0;
   z-index: 1;
-  background: #aad3df; /* ocean colour shown before tiles arrive */
+  background: #9ebcd8; /* ocean colour shown before tiles arrive */
 }
 
 


### PR DESCRIPTION
This PR chanegs the background colour to match the ocean colour of the tiles, and remvoes no wrapping which reveals (non interactive land mass on the left). But this is better than nowrap being true as a large blue space which looks weird appears.

<img width="2557" height="1323" alt="image" src="https://github.com/user-attachments/assets/ae1a8e2a-9b0d-458d-a79a-3c88cd78a2ff" />
